### PR TITLE
Fix: add ReadCliPipes permission for pipe commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ impl ZellijPlugin for State {
         request_permission(&[
             PermissionType::ReadApplicationState,
             PermissionType::ChangeApplicationState,
+            PermissionType::ReadCliPipes,
         ]);
         subscribe(&[EventType::TabUpdate, EventType::PaneUpdate]);
     }


### PR DESCRIPTION
## Summary
- Add missing `ReadCliPipes` permission to plugin's `load()` function
- Without this permission, `unblock_cli_pipe_input()` and `cli_pipe_output()` are denied by Zellij 0.43.x, causing all pipe commands (`--get`, `--set-name`, `--clear`, etc.) to silently hang and timeout

## Test plan
- [ ] `make build && make install`
- [ ] Start a new Zellij session
- [ ] Accept the permissions dialog (now includes `ReadCliPipes`)
- [ ] Verify `zellij-tab-status -g` returns status emoji
- [ ] Verify `zellij-tab-status --set-name "test"` renames the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)