### PR TITLE
Fix: use CLI pipe ID for output routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "zellij-tab-status"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zellij-tab-status"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Danil Pismenny <danilpismenny@gmail.com>"]
 description = "Zellij plugin for managing tab status with emoji prefixes"


### PR DESCRIPTION
## Summary
- `cli_pipe_output()` and `unblock_cli_pipe_input()` require the unique pipe_id from `PipeSource::Cli`, not the pipe name "tab-status"
- Using the wrong identifier caused all pipe responses (`get_status`, `get_name`, `set_name`, etc.) to silently fail — output never reached the CLI client
- Now extracts `pipe_id` from `pipe_message.source` and uses it for both output and unblocking

## Test plan
- [x] `zellij-tab-status -n` returns tab name
- [x] `zellij-tab-status -g` returns current status emoji
- [x] `zellij-tab-status --set-name <name>` renames tab correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)