### PR TITLE
Fix native cargo test linker failure for plugin binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo clippy --target wasm32-wasip1 -- -D warnings
 
       - name: Test
-        run: cargo test --lib
+        run: cargo test
 
       - name: Build
         run: cargo build --release --target wasm32-wasip1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,12 @@ description = "Zellij plugin for managing tab status with emoji prefixes"
 license = "MIT"
 repository = "https://github.com/dapi/zellij-tab-status"
 
+[[bin]]
+name = "zellij-tab-status"
+path = "src/main.rs"
+# Plugin host symbols exist only inside Zellij runtime.
+test = false
+
 [dependencies]
 zellij-tile = "0.43.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ install-scripts:
 clean:
 	cargo clean
 
-# Run unit tests (library only, no WASM runtime needed)
+# Run host tests (bin test harness is disabled in Cargo.toml)
 test:
-	cargo test --lib
+	cargo test
 
 # Test in live Zellij session (run after installing and restarting zellij)
 test-live:

--- a/README.md
+++ b/README.md
@@ -285,7 +285,10 @@ make install
 # Clean
 make clean
 
-# Run unit tests
+# Run host tests (plain `cargo test` should be green)
+# Note: binary test harness is disabled in Cargo.toml because
+# zellij-tile host symbols are only available inside Zellij runtime.
+cargo test
 make test
 
 # Test in live Zellij session (after make install)


### PR DESCRIPTION
## Summary
- disable test harness for plugin binary target (`src/main.rs`) via Cargo `[[bin]] test = false`
- switch local/CI default host test path to plain `cargo test`
- document why binary harness is disabled (host-only zellij symbols)

## Why
`cargo test` on native host was trying to link the binary test harness and failed on unresolved `host_run_plugin_command`.

## Validation
- `cargo test`
- `make test`
- `cargo build --release --target wasm32-wasip1`

Closes #8
