### PR TITLE
fix: manual tab rename overwritten by plugin (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,7 @@ For integration tests in Docker, the plugin IS pre-loaded via `load_plugins` in 
 
 ### State Management
 
-- `pane_to_tab: PaneTabMap` (alias for `BTreeMap<u32, (usize, String)>`) — maps pane_id to (tab_position, tab_name). Rebuilt on every `TabUpdate` or `PaneUpdate` event
-- `pending_renames: BTreeMap<usize, String>` — protects against `rebuild_mapping` overwriting inline cache updates with stale tab names before `TabUpdate` confirms a rename
+- `pane_to_tab: BTreeMap<u32, usize>` — maps pane_id → tab_position (0-indexed). Must NOT store tab names — names are always read fresh from `self.tabs` (latest TabUpdate). Rebuilt on every `TabUpdate` or `PaneUpdate` event
 - `tab_indices: Vec<u32>` — maps tab position → persistent Zellij tab index (workaround for Zellij bug #3535)
 - `next_tab_index: u32` — counter for assigning indices to newly created tabs
 - `pane_tab_index: HashMap<u32, u32>` — maps pane_id → persistent tab_index. Pane IDs are stable anchors for identifying tabs across structural changes (deletions/creations)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: build install install-scripts clean test test-live test-integration test-plugin-dedup test-issue5-regression test-issue6-regression test-issue6-raw-regression
+.PHONY: build install install-scripts clean test test-live test-integration test-plugin-dedup test-issue5-regression test-issue6-regression test-issue6-raw-regression test-issue10-regression
 
 PLUGIN_NAME = zellij-tab-status
 TARGET = target/wasm32-wasip1/release/zellij-tab-status.wasm
 INSTALL_DIR = $(HOME)/.config/zellij/plugins
 SCRIPTS_DIR = $(HOME)/.local/bin
 TEST_PLUGIN_MODE ?= preloaded
+ISSUE10_ATTEMPTS ?= 3
+ISSUE10_TAB_COUNT ?= 24
+ISSUE10_PROBE_ROUNDS ?= 10
+ISSUE10_READY_TIMEOUT ?= 20
+ISSUE10_ACTION_TIMEOUT ?= 5
+ISSUE10_RUN_TIMEOUT ?= 240
 
 build:
 	cargo build --release --target wasm32-wasip1
@@ -82,3 +88,18 @@ test-issue6-raw-regression: build
 		-v "$$(pwd)/scripts:/test/scripts:ro" \
 		zellij-tab-status-test \
 		/test/scripts/issue6-raw-regression-check.sh
+
+# Regression check for issue #10 (many tabs: no lost names after probing)
+test-issue10-regression: build
+	docker build -f Dockerfile.test -t zellij-tab-status-test .
+	docker run --rm \
+		-e ISSUE10_ATTEMPTS="$(ISSUE10_ATTEMPTS)" \
+		-e ISSUE10_TAB_COUNT="$(ISSUE10_TAB_COUNT)" \
+		-e ISSUE10_PROBE_ROUNDS="$(ISSUE10_PROBE_ROUNDS)" \
+		-e ISSUE10_READY_TIMEOUT="$(ISSUE10_READY_TIMEOUT)" \
+		-e ISSUE10_ACTION_TIMEOUT="$(ISSUE10_ACTION_TIMEOUT)" \
+		-e ISSUE10_RUN_TIMEOUT="$(ISSUE10_RUN_TIMEOUT)" \
+		-v "$$(pwd)/$(TARGET):/test/plugin.wasm:ro" \
+		-v "$$(pwd)/scripts:/test/scripts:ro" \
+		zellij-tab-status-test \
+		/test/scripts/issue10-regression-check.sh


### PR DESCRIPTION
## Summary

- Remove tab name caching from plugin state entirely — `pane_to_tab` now stores only `pane_id → position`, never names
- Remove `PendingRename` mechanism that caused stale cached names to overwrite user's manual renames
- Tab names are always read fresh from the latest `TabUpdate` via `tab_names()` helper
- Add 3 integration tests (24-26) covering manual rename scenarios

Closes #11

## Test plan

- [x] 34 unit tests pass (`cargo test --lib`)
- [x] WASM build passes (`cargo build --release --target wasm32-wasip1`)
- [x] 137 integration assertions pass (`make test-integration`), including:
  - Test 24: Manual rename preserved after set_status
  - Test 25: Manual rename without prior status
  - Test 26: Multi-tab manual rename on one tab, status on another

🤖 Generated with [Claude Code](https://claude.com/claude-code)